### PR TITLE
fix: Suppress InsecureRequestWarning for specific domains

### DIFF
--- a/loadusc/downloadusc.py
+++ b/loadusc/downloadusc.py
@@ -36,7 +36,9 @@ except ImportError:
         USC_RP_TEXT,
         USC_XML_TEXT,
     )
-
+    
+# Disable InsecureRequestWarning warnings since uscode.house.gov uses self-signed certificates
+requests.packages.urllib3.disable_warnings(category=urllib3.exceptions.InsecureRequestWarning)
 
 URL_ATTEMPTS_MAX = 20
 


### PR DESCRIPTION
Suppress InsecureRequestWarning warnings due to the use of self-signed certificates on uscode.house.gov.